### PR TITLE
main: Enable riscv_ext_intrinsics feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,8 @@
     core_intrinsics,
     naked_functions,
     asm_const,
-    stdsimd
+    stdsimd,
+    riscv_ext_intrinsics
 )]
 
 #[macro_use]


### PR DESCRIPTION
This commit is to solve the following build error:
```
error[E0658]: use of unstable library feature 'riscv_ext_intrinsics'
   --> src/guest/vmexit.rs:236:9
    |
236 |         core::arch::riscv64::hfence_gvma_all();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #114544 <https://github.com/rust-lang/rust/issues/114544> for more information
    = help: add `#![feature(riscv_ext_intrinsics)]` to the crate attributes to enable
```